### PR TITLE
Use controller_action_predispatch event to handle the headers logic

### DIFF
--- a/code/Block/Beforebodyend.php
+++ b/code/Block/Beforebodyend.php
@@ -5,60 +5,6 @@
  *
  * @author Fabrizio Branca
  */
-class Aoe_Static_Block_Beforebodyend extends Mage_Core_Block_Template {
-
-
-
-	/**
-	 * Send headers to tell varnish whether this page should be cached or not
-	 *
-	 * @return void
-	 */
-	public function sendHeaders() {
-		$fullActionName = $this->getFullActionName();
-		$lifeTime = $this->isCacheableAction($fullActionName);
-		$response = Mage::app()->getResponse();
-		$response->setHeader('Magento_Lifetime', $lifeTime, true); // Only for debugging and information
-		$response->setHeader('Magento_Action', $fullActionName, true); // Only for debugging and information
-		if ($lifeTime) {
-			$response->setHeader('Cache-Control', 'max-age='.$lifeTime, true);
-			// $response->setHeader('Pragma', 'public', true);
-			$response->setHeader('aoestatic', 'cache', true);
-		}
-	}
-
-
-
-	/**
-	 * Check if a fullActionName is configured as cacheable
-	 *
-	 * @param string $fullActionName
-	 * @return false|int false if not cacheable, otherwise lifetime in seconds
-	 */
-	public function isCacheableAction($fullActionName) {
-		$cacheActionsString = Mage::getStoreConfig('system/aoe_static/cache_actions');
-		foreach (explode(',', $cacheActionsString) as $singleActionConfiguration) {
-			list($actionName, $lifeTime) = explode(';', $singleActionConfiguration);
-			if (trim($actionName) == $fullActionName) {
-				return intval(trim($lifeTime));
-			}
-		}
-		return false;
-	}
-
-
-
-	/**
-	 * Get full action name
-	 *
-	 * @return string
-	 * @author Fabrizio Branca <fabrizio.branca@aoemedia.de>
-	 */
-	public function getFullActionName() {
-		$request = Mage::app()->getRequest();
-		return $request->getRequestedRouteName().'_'.
-			$request->getRequestedControllerName().'_'.
-			$request->getRequestedActionName();
-	}
-
+class Aoe_Static_Block_Beforebodyend extends Mage_Core_Block_Template 
+{
 }

--- a/code/Helper/Data.php
+++ b/code/Helper/Data.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Data helper
+ *
+ * @category    Aoe
+ * @package     Aoe_Static
+ * @author      Toni Grigoriu <toni@tonigrigoriu.com>
+ */
+class Aoe_Static_Helper_Data extends Mage_Core_Helper_Abstract
+{
+    /**
+	 * Check if a fullActionName is configured as cacheable
+	 *
+	 * @param string $fullActionName
+	 * @return false|int false if not cacheable, otherwise lifetime in seconds
+	 */
+	public function isCacheableAction($fullActionName)
+    {
+		$cacheActionsString = Mage::getStoreConfig('system/aoe_static/cache_actions');
+		foreach (explode(',', $cacheActionsString) as $singleActionConfiguration) {
+			list($actionName, $lifeTime) = explode(';', $singleActionConfiguration);
+			if (trim($actionName) == $fullActionName) {
+				return intval(trim($lifeTime));
+			}
+		}
+		return false;
+	}
+}

--- a/code/Helper/Data.php
+++ b/code/Helper/Data.php
@@ -10,20 +10,20 @@
 class Aoe_Static_Helper_Data extends Mage_Core_Helper_Abstract
 {
     /**
-	 * Check if a fullActionName is configured as cacheable
-	 *
-	 * @param string $fullActionName
-	 * @return false|int false if not cacheable, otherwise lifetime in seconds
-	 */
-	public function isCacheableAction($fullActionName)
+     * Check if a fullActionName is configured as cacheable
+     *
+     * @param string $fullActionName
+     * @return false|int false if not cacheable, otherwise lifetime in seconds
+     */
+    public function isCacheableAction($fullActionName)
     {
-		$cacheActionsString = Mage::getStoreConfig('system/aoe_static/cache_actions');
-		foreach (explode(',', $cacheActionsString) as $singleActionConfiguration) {
-			list($actionName, $lifeTime) = explode(';', $singleActionConfiguration);
-			if (trim($actionName) == $fullActionName) {
-				return intval(trim($lifeTime));
-			}
-		}
-		return false;
+        $cacheActionsString = Mage::getStoreConfig('system/aoe_static/cache_actions');
+        foreach (explode(',', $cacheActionsString) as $singleActionConfiguration) {
+            list($actionName, $lifeTime) = explode(';', $singleActionConfiguration);
+            if (trim($actionName) == $fullActionName) {
+                return intval(trim($lifeTime));
+            }
+        }
+        return false;
 	}
 }

--- a/code/Model/Observer.php
+++ b/code/Model/Observer.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Observer model
+ *
+ * @category    Aoe
+ * @package     Aoe_Static
+ * @author      Toni Grigoriu <toni@tonigrigoriu.com>
+ */
+class Aoe_Static_Model_Observer
+{
+    /**
+     * Check when varnish caching should be enabled.
+     *
+     * @param Varien_Event_Observer $observer
+     * @return Aoe_Static_Model_Observer
+     */
+    public function processPreDispatch(Varien_Event_Observer $observer)
+    {
+        /* @var $helper Aoe_Static_Helper_Data */
+        $helper = Mage::helper('aoestatic');
+        
+        $controllerAction = $observer->getEvent()->getControllerAction();
+        
+        /* @var $request Mage_Core_Controller_Request_Http */
+        $request = $controllerAction->getRequest();
+        /* @var $response Mage_Core_Controller_Response_Http */
+        $response = $controllerAction->getResponse();
+        
+        $fullActionName = $controllerAction->getFullActionName();
+        
+        $lifetime = $helper->isCacheableAction($fullActionName);
+        
+        if (!$lifetime) {
+            return $this;
+        }
+        
+        $response->setHeader('X-Magento-Lifetime', $lifetime, true); // Only for debugging and information
+		$response->setHeader('X-Magento-Action', $fullActionName, true); // Only for debugging and information
+        $response->setHeader('Cache-Control', 'max-age='. $lifetime, true);
+    	$response->setHeader('aoestatic', 'cache', true);
+		
+        return $this;
+    }
+}

--- a/code/Model/Observer.php
+++ b/code/Model/Observer.php
@@ -35,9 +35,9 @@ class Aoe_Static_Model_Observer
         }
         
         $response->setHeader('X-Magento-Lifetime', $lifetime, true); // Only for debugging and information
-		$response->setHeader('X-Magento-Action', $fullActionName, true); // Only for debugging and information
+        $response->setHeader('X-Magento-Action', $fullActionName, true); // Only for debugging and information
         $response->setHeader('Cache-Control', 'max-age='. $lifetime, true);
-    	$response->setHeader('aoestatic', 'cache', true);
+        $response->setHeader('aoestatic', 'cache', true);
 		
         return $this;
     }

--- a/code/etc/config.xml
+++ b/code/etc/config.xml
@@ -15,6 +15,16 @@
 				<class>Aoe_Static_Block</class>
 			</aoestatic>
 		</blocks>
+        <models>
+            <aoestatic>
+                <class>Aoe_Static_Model</class>
+            </aoestatic>
+        </models>
+        <helpers>
+            <aoestatic>
+                <class>Aoe_Static_Helper</class>
+            </aoestatic>
+        </helpers>
 	</global>
 
 	<frontend>
@@ -25,7 +35,6 @@
 				</aoestatic>
 			</updates>
 		</layout>
-
 		<routers>
 			<aoestatic>
 				<use>standard</use>
@@ -34,8 +43,17 @@
 					<frontName>phone</frontName>
 				</args>
 			</aoestatic>
-		</routers>
-
+		</routers>        
+        <events>
+            <controller_action_predispatch>
+                <observers>
+                    <aoestatic>
+                        <class>aoestatic/observer</class>
+                        <method>processPreDispatch</method>
+                    </aoestatic>
+                </observers>
+            </controller_action_predispatch>
+        </events>
 	</frontend>
 
 	<default>
@@ -47,6 +65,11 @@ catalog_product_view;86400,
 catalog_category_view;86400]]></cache_actions>
 			</aoe_static>
 		</system>
+        <dev>
+            <template>
+                <allow_symlink>1</allow_symlink>
+            </template>
+        </dev>
 	</default>
 
 </config>

--- a/frontend/template/aoestatic/beforebodyend.phtml
+++ b/frontend/template/aoestatic/beforebodyend.phtml
@@ -1,11 +1,10 @@
-<?php $view = $this; /* @var $view Aoe_Static_Block_Beforebodyend */?>
+<?php /* @var $this Aoe_Static_Block_Beforebodyend */?>
 <script type="text/javascript">
 //<![CDATA[
     var AJAXHOME_URL = '<?php echo Mage::getUrl('phone/call/index') ?>';
-    var FULLACTIONNAME = '<?php echo $view->getFullActionName() ?>';
+    var FULLACTIONNAME = '<?php echo $this->getAction()->getFullActionName() ?>';
     <?php if (($_product = Mage::registry('product')) == true) : ?>
     var CURRENTPRODUCTID = '<?php echo $_product->getId() ?>';
     <?php endif; ?>
 //]]>
 </script>
-<?php $view->sendHeaders(); ?>


### PR DESCRIPTION
Great work with this module. I moved all the logic from the block to the observer and data helper and replaced the getFullActionName in the template with the core method in Mage_Core_Controller_Varien_Action. Tested on CE 1.5.1.0

Cheers,
Toni
